### PR TITLE
refactor(quotes): enhance async capabilities

### DIFF
--- a/pkg/quotes/bitfaker.go
+++ b/pkg/quotes/bitfaker.go
@@ -10,16 +10,16 @@ import (
 
 type bitfaker struct {
 	mu           sync.RWMutex
-	outbox       chan<- TradeEvent
 	markets      []Market
+	outbox       chan<- TradeEvent
 	period       time.Duration
 	tradeSampler tradeSampler
 }
 
 func newBitfaker(config Config, outbox chan<- TradeEvent) *bitfaker {
 	return &bitfaker{
-		outbox:       outbox,
 		markets:      make([]Market, 0),
+		outbox:       outbox,
 		period:       5 * time.Second,
 		tradeSampler: *newTradeSampler(config.TradeSampler),
 	}

--- a/pkg/quotes/bitfaker.go
+++ b/pkg/quotes/bitfaker.go
@@ -14,7 +14,7 @@ type bitfaker struct {
 	outbox       chan<- TradeEvent
 	markets      []Market
 	period       time.Duration
-	tradeSampler *tradeSampler
+	tradeSampler tradeSampler
 }
 
 func newBitfaker(config Config, outbox chan<- TradeEvent) *bitfaker {
@@ -22,7 +22,7 @@ func newBitfaker(config Config, outbox chan<- TradeEvent) *bitfaker {
 		outbox:       outbox,
 		markets:      make([]Market, 0),
 		period:       5 * time.Second,
-		tradeSampler: newTradeSampler(config.TradeSampler),
+		tradeSampler: *newTradeSampler(config.TradeSampler),
 	}
 }
 
@@ -53,6 +53,12 @@ func (b *bitfaker) Start(markets []Market) error {
 func (b *bitfaker) Subscribe(market Market) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+
+	for _, m := range b.markets {
+		if m == market {
+			return fmt.Errorf("market %s already subscribed", market)
+		}
+	}
 
 	b.markets = append(b.markets, market)
 	return nil

--- a/pkg/quotes/bitfaker.go
+++ b/pkg/quotes/bitfaker.go
@@ -1,7 +1,6 @@
 package quotes
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -26,17 +25,7 @@ func newBitfaker(config Config, outbox chan<- TradeEvent) *bitfaker {
 	}
 }
 
-func (b *bitfaker) Start(markets []Market) error {
-	if len(markets) == 0 {
-		return errors.New("no markets specified")
-	}
-
-	for _, m := range markets {
-		if err := b.Subscribe(m); err != nil {
-			return err
-		}
-	}
-
+func (b *bitfaker) Start() error {
 	go func() {
 		for {
 			b.mu.RLock()

--- a/pkg/quotes/bitfaker.go
+++ b/pkg/quotes/bitfaker.go
@@ -67,7 +67,7 @@ func (b *bitfaker) Subscribe(market Market) error {
 
 	for _, m := range b.streams {
 		if m == market {
-			return fmt.Errorf("market %s already subscribed", market)
+			return fmt.Errorf("%s: %w", market, ErrAlreadySubbed)
 		}
 	}
 
@@ -88,7 +88,7 @@ func (b *bitfaker) Unsubscribe(market Market) error {
 	}
 
 	if index == -1 {
-		return fmt.Errorf("market %s not found", market)
+		return fmt.Errorf("%s: %w", market, ErrNotSubbed)
 	}
 
 	b.streams = append(b.streams[:index], b.streams[index+1:]...)

--- a/pkg/quotes/bitfaker_test.go
+++ b/pkg/quotes/bitfaker_test.go
@@ -24,7 +24,7 @@ func TestBitfaker_Subscribe(t *testing.T) {
 		require.Nil(t, err)
 
 		expectedMarkets := []Market{m}
-		assert.Equal(t, client.markets, expectedMarkets)
+		assert.Equal(t, client.streams, expectedMarkets)
 	})
 
 	t.Run("Multiple markets", func(t *testing.T) {
@@ -42,7 +42,7 @@ func TestBitfaker_Subscribe(t *testing.T) {
 		require.Nil(t, err)
 
 		expectedMarkets := []Market{market1, market2}
-		assert.Equal(t, client.markets, expectedMarkets)
+		assert.Equal(t, client.streams, expectedMarkets)
 	})
 
 	t.Run("Subscribe to a market already subscribed to", func(t *testing.T) {
@@ -77,8 +77,8 @@ func TestBitfaker_Unsubscribe(t *testing.T) {
 		require.NoError(t, client.Unsubscribe(market1))
 		require.NoError(t, client.Unsubscribe(market2))
 
-		assert.NotContains(t, client.markets, market1)
-		assert.NotContains(t, client.markets, market2)
+		assert.NotContains(t, client.streams, market1)
+		assert.NotContains(t, client.streams, market2)
 	})
 
 	t.Run("Unsubscribe from a market not subscribed to", func(t *testing.T) {
@@ -106,8 +106,8 @@ func TestBitfaker_Unsubscribe(t *testing.T) {
 
 		require.NoError(t, client.Unsubscribe(market1))
 
-		assert.NotContains(t, client.markets, market1)
-		assert.Contains(t, client.markets, market2)
+		assert.NotContains(t, client.streams, market1)
+		assert.Contains(t, client.streams, market2)
 	})
 }
 
@@ -119,7 +119,12 @@ func TestBitfaker_Start(t *testing.T) {
 		Enabled:           false,
 		DefaultPercentage: 0,
 	})
-	client := bitfaker{outbox: outbox, period: 0 * time.Second, tradeSampler: tradeSampler}
+	client := bitfaker{
+		once:         newOnce(),
+		outbox:       outbox,
+		period:       0 * time.Second,
+		tradeSampler: tradeSampler,
+	}
 	market := Market{BaseUnit: "btc", QuoteUnit: "usd"}
 
 	var wg sync.WaitGroup

--- a/pkg/quotes/bitfaker_test.go
+++ b/pkg/quotes/bitfaker_test.go
@@ -11,7 +11,11 @@ import (
 )
 
 func TestBitfaker_Subscribe(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Single market", func(t *testing.T) {
+		t.Parallel()
+
 		ch := make(chan TradeEvent, 16)
 		client := bitfaker{outbox: ch}
 
@@ -24,6 +28,8 @@ func TestBitfaker_Subscribe(t *testing.T) {
 	})
 
 	t.Run("Multiple markets", func(t *testing.T) {
+		t.Parallel()
+
 		outbox := make(chan TradeEvent, 16)
 		client := bitfaker{outbox: outbox}
 
@@ -40,6 +46,8 @@ func TestBitfaker_Subscribe(t *testing.T) {
 	})
 
 	t.Run("Subscribe to a market already subscribed to", func(t *testing.T) {
+		t.Parallel()
+
 		ch := make(chan TradeEvent, 16)
 		client := bitfaker{outbox: ch}
 
@@ -53,7 +61,11 @@ func TestBitfaker_Subscribe(t *testing.T) {
 }
 
 func TestBitfaker_Unsubscribe(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Unsubscribe from multiple markets", func(t *testing.T) {
+		t.Parallel()
+
 		ch := make(chan TradeEvent, 16)
 		client := bitfaker{outbox: ch}
 
@@ -70,6 +82,8 @@ func TestBitfaker_Unsubscribe(t *testing.T) {
 	})
 
 	t.Run("Unsubscribe from a market not subscribed to", func(t *testing.T) {
+		t.Parallel()
+
 		ch := make(chan TradeEvent, 16)
 		client := bitfaker{outbox: ch}
 
@@ -80,6 +94,8 @@ func TestBitfaker_Unsubscribe(t *testing.T) {
 	})
 
 	t.Run("No effect on other subscriptions after unsubscribing", func(t *testing.T) {
+		t.Parallel()
+
 		ch := make(chan TradeEvent, 16)
 		client := bitfaker{outbox: ch}
 
@@ -96,6 +112,8 @@ func TestBitfaker_Unsubscribe(t *testing.T) {
 }
 
 func TestBitfaker_Start(t *testing.T) {
+	t.Parallel()
+
 	outbox := make(chan TradeEvent, 1)
 	tradeSampler := *newTradeSampler(TradeSamplerConfig{
 		Enabled:           false,
@@ -121,6 +139,8 @@ func TestBitfaker_Start(t *testing.T) {
 }
 
 func TestCreateTradeEvent(t *testing.T) {
+	t.Parallel()
+
 	outbox := make(chan TradeEvent)
 	client := bitfaker{outbox: outbox}
 

--- a/pkg/quotes/bitfaker_test.go
+++ b/pkg/quotes/bitfaker_test.go
@@ -107,8 +107,7 @@ func TestBitfaker_Start(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
-		err := client.Start([]Market{market})
-		require.NoError(t, err)
+		require.NoError(t, client.Start())
 		wg.Done()
 	}()
 	go func() {

--- a/pkg/quotes/interface.go
+++ b/pkg/quotes/interface.go
@@ -12,10 +12,10 @@ import (
 var logger = log.Logger("quotes")
 
 type Driver interface {
-	Subscribe(market Market) error
-	Unsubscribe(market Market) error
 	Start() error
 	Stop() error
+	Subscribe(market Market) error
+	Unsubscribe(market Market) error
 }
 
 func NewDriver(config Config, outbox chan<- TradeEvent) (Driver, error) {

--- a/pkg/quotes/interface.go
+++ b/pkg/quotes/interface.go
@@ -14,7 +14,7 @@ var logger = log.Logger("quotes")
 type Driver interface {
 	Subscribe(market Market) error
 	Unsubscribe(market Market) error
-	Start(markets []Market) error
+	Start() error
 	Stop() error
 }
 

--- a/pkg/quotes/interface.go
+++ b/pkg/quotes/interface.go
@@ -2,6 +2,7 @@
 package quotes
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -62,3 +63,10 @@ type TradeEvent struct {
 	TakerType TakerType
 	CreatedAt time.Time
 }
+
+var (
+	ErrNotSubbed     = errors.New("market not subscribed")
+	ErrAlreadySubbed = errors.New("market already subscribed")
+	ErrFailedSub     = errors.New("failed to subscribe to market")
+	ErrFailedUnsub   = errors.New("failed to unsubscribe from market")
+)

--- a/pkg/quotes/interface_test.go
+++ b/pkg/quotes/interface_test.go
@@ -8,7 +8,11 @@ import (
 )
 
 func TestNewDriver(t *testing.T) {
+	t.Parallel()
+
 	t.Run(DriverBinance.String(), func(t *testing.T) {
+		t.Parallel()
+
 		config := Config{Driver: DriverBinance}
 		outbox := make(chan<- TradeEvent, 1)
 
@@ -18,6 +22,8 @@ func TestNewDriver(t *testing.T) {
 	})
 
 	t.Run(DriverKraken.String(), func(t *testing.T) {
+		t.Parallel()
+
 		config := Config{Driver: DriverKraken}
 		outbox := make(chan<- TradeEvent, 1)
 
@@ -27,6 +33,8 @@ func TestNewDriver(t *testing.T) {
 	})
 
 	t.Run(DriverBitfaker.String(), func(t *testing.T) {
+		t.Parallel()
+
 		config := Config{Driver: DriverBitfaker}
 		outbox := make(chan<- TradeEvent, 1)
 
@@ -36,6 +44,8 @@ func TestNewDriver(t *testing.T) {
 	})
 
 	t.Run(DriverOpendax.String(), func(t *testing.T) {
+		t.Parallel()
+
 		config := Config{Driver: DriverOpendax}
 		outbox := make(chan<- TradeEvent, 1)
 
@@ -45,6 +55,8 @@ func TestNewDriver(t *testing.T) {
 	})
 
 	t.Run("Unknown driver", func(t *testing.T) {
+		t.Parallel()
+
 		priceFeeds, err := NewDriver(
 			Config{Driver: DriverType{"wtf"}},
 			make(chan<- TradeEvent, 1),

--- a/pkg/quotes/interface_test.go
+++ b/pkg/quotes/interface_test.go
@@ -18,7 +18,8 @@ func TestNewDriver(t *testing.T) {
 
 		priceFeeds, err := NewDriver(config, outbox)
 		require.NoError(t, err)
-		assert.Equal(t, newBinance(config, outbox), priceFeeds)
+		_, ok := priceFeeds.(*binance)
+		assert.True(t, ok)
 	})
 
 	t.Run(DriverKraken.String(), func(t *testing.T) {
@@ -29,7 +30,8 @@ func TestNewDriver(t *testing.T) {
 
 		priceFeeds, err := NewDriver(config, outbox)
 		require.NoError(t, err)
-		assert.Equal(t, newKraken(config, outbox), priceFeeds)
+		_, ok := priceFeeds.(*kraken)
+		assert.True(t, ok)
 	})
 
 	t.Run(DriverBitfaker.String(), func(t *testing.T) {
@@ -40,7 +42,8 @@ func TestNewDriver(t *testing.T) {
 
 		priceFeeds, err := NewDriver(config, outbox)
 		require.NoError(t, err)
-		assert.Equal(t, newBitfaker(config, outbox), priceFeeds)
+		_, ok := priceFeeds.(*bitfaker)
+		assert.True(t, ok)
 	})
 
 	t.Run(DriverOpendax.String(), func(t *testing.T) {
@@ -51,7 +54,8 @@ func TestNewDriver(t *testing.T) {
 
 		priceFeeds, err := NewDriver(config, outbox)
 		require.NoError(t, err)
-		assert.Equal(t, newOpendax(config, outbox), priceFeeds)
+		_, ok := priceFeeds.(*opendax)
+		assert.True(t, ok)
 	})
 
 	t.Run("Unknown driver", func(t *testing.T) {

--- a/pkg/quotes/once.go
+++ b/pkg/quotes/once.go
@@ -1,0 +1,32 @@
+package quotes
+
+import (
+	"sync"
+)
+
+// once manages the synchronization of starting and stopping a process.
+// It ensures that the start and stop functions are called IN ORDER and ONLY ONCE.
+type once struct {
+	startOnce sync.Once
+	stopOnce  sync.Once
+}
+
+func newOnce() *once {
+	sm := &once{}
+	sm.Stop(func() {})
+	return sm
+}
+
+func (sm *once) Start(f func()) {
+	sm.startOnce.Do(func() {
+		f()
+		sm.stopOnce = sync.Once{} // allow a new stop
+	})
+}
+
+func (sm *once) Stop(f func()) {
+	sm.stopOnce.Do(func() {
+		f()
+		sm.startOnce = sync.Once{} // allow a new start
+	})
+}

--- a/pkg/quotes/once_test.go
+++ b/pkg/quotes/once_test.go
@@ -1,0 +1,71 @@
+package quotes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOnce_Start(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Should call the function only once", func(t *testing.T) {
+		t.Parallel()
+
+		o := newOnce()
+		startedChan := make(chan bool, 2)
+		defer close(startedChan)
+
+		o.Start(func() { startedChan <- true })
+		o.Start(func() { startedChan <- true })
+
+		require.Len(t, startedChan, 1, "Start() method was executed more than once")
+	})
+
+	t.Run("Should reset the STOP action", func(t *testing.T) {
+		t.Parallel()
+
+		o := newOnce()
+		startedChan := make(chan bool, 2)
+		defer close(startedChan)
+
+		o.Start(func() { startedChan <- true })
+		o.Stop(func() {})
+		o.Start(func() { startedChan <- true })
+
+		require.Len(t, startedChan, 2)
+	})
+}
+
+func TestOnce_Stop(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Should call the function only once", func(t *testing.T) {
+		t.Parallel()
+
+		o := newOnce()
+		stoppedChan := make(chan bool, 2)
+		defer close(stoppedChan)
+
+		o.Start(func() {}) // start the process to unblock STOP action
+		o.Stop(func() { stoppedChan <- true })
+		o.Stop(func() { stoppedChan <- true })
+
+		require.Len(t, stoppedChan, 1, "Stop() method was executed more than once")
+	})
+
+	t.Run("Should reset the START action", func(t *testing.T) {
+		t.Parallel()
+
+		o := newOnce()
+		stoppedChan := make(chan bool, 2)
+		defer close(stoppedChan)
+
+		o.Start(func() {}) // start the process to unblock STOP action
+		o.Stop(func() { stoppedChan <- true })
+		o.Start(func() {})
+		o.Stop(func() { stoppedChan <- true })
+
+		require.Len(t, stoppedChan, 2)
+	})
+}

--- a/pkg/quotes/opendax.go
+++ b/pkg/quotes/opendax.go
@@ -65,7 +65,7 @@ func (o *opendax) Stop() error {
 
 func (o *opendax) Subscribe(market Market) error {
 	if _, ok := o.streams.Load(market); ok {
-		return fmt.Errorf("market %s already subscribed", market)
+		return fmt.Errorf("%s: %w", market, ErrAlreadySubbed)
 	}
 
 	// Opendax resource [market].[trades]
@@ -75,7 +75,7 @@ func (o *opendax) Subscribe(market Market) error {
 
 	err := o.writeConn(message)
 	if err != nil {
-		return err
+		return fmt.Errorf("%s: %w: %w", market, ErrFailedSub, err)
 	}
 
 	o.streams.Store(market, struct{}{})
@@ -84,7 +84,7 @@ func (o *opendax) Subscribe(market Market) error {
 
 func (o *opendax) Unsubscribe(market Market) error {
 	if _, ok := o.streams.Load(market); !ok {
-		return fmt.Errorf("market %s not subscribed", market)
+		return fmt.Errorf("%s: %w", market, ErrNotSubbed)
 	}
 
 	// Opendax resource [market].[trades]
@@ -94,7 +94,7 @@ func (o *opendax) Unsubscribe(market Market) error {
 
 	err := o.writeConn(message)
 	if err != nil {
-		return err
+		return fmt.Errorf("%s: %w: %w", market, ErrFailedUnsub, err)
 	}
 
 	o.streams.Delete(market)

--- a/pkg/quotes/opendax_protocol/args_iterator_test.go
+++ b/pkg/quotes/opendax_protocol/args_iterator_test.go
@@ -7,22 +7,25 @@ import (
 )
 
 func TestArgsIterator(t *testing.T) {
-	args := []interface{}{
-		float64(1),
-		"123",
-		float64(3),
-		"145",
-		float64(3),
-		"145",
-		"56.89",
-		"hello",
-		float64(0.65),
-		true,
-		12345.565656,
-		[]interface{}{1, 2, "hello"},
-	}
+	t.Parallel()
 
 	t.Run("no errors", func(t *testing.T) {
+		t.Parallel()
+
+		args := []interface{}{
+			float64(1),
+			"123",
+			float64(3),
+			"145",
+			float64(3),
+			"145",
+			"56.89",
+			"hello",
+			float64(0.65),
+			true,
+			12345.565656,
+			[]interface{}{1, 2, "hello"},
+		}
 		it := NewArgIterator(args)
 
 		uintv := it.NextUint64()
@@ -78,14 +81,16 @@ func TestArgsIterator(t *testing.T) {
 	})
 
 	t.Run("no errors", func(t *testing.T) {
+		t.Parallel()
+
 		args := []interface{}{
 			"123",
 			"56.89",
 			"hello",
 		}
-		res := []string{}
-
 		it := NewArgIterator(args)
+
+		var res []string
 		for it.More() {
 			res = append(res, it.NextString())
 		}

--- a/pkg/quotes/opendax_protocol/msg_test.go
+++ b/pkg/quotes/opendax_protocol/msg_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestEncoding(t *testing.T) {
+	t.Parallel()
+
 	msg := Msg{
 		Type:   Request,
 		ReqID:  42,
@@ -21,6 +23,8 @@ func TestEncoding(t *testing.T) {
 }
 
 func TestEncodingEvent(t *testing.T) {
+	t.Parallel()
+
 	msg := Msg{
 		Type:   EventPrivate,
 		ReqID:  42,

--- a/pkg/quotes/opendax_protocol/parser_test.go
+++ b/pkg/quotes/opendax_protocol/parser_test.go
@@ -6,90 +6,106 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParserSuccess(t *testing.T) {
-	msg, err := ParseRaw([]byte(`[1,42,"ping",[]]`))
-	assert.NoError(t, err)
-	assert.Equal(t,
-		&Msg{
-			Type:   Request,
-			ReqID:  42,
-			Method: "ping",
-			Args:   []interface{}{},
-		}, msg)
+func TestParseRaw(t *testing.T) {
+	t.Parallel()
 
-	msg, err = ParseRaw([]byte(`[2,42,"pong",[]]`))
-	assert.NoError(t, err)
-	assert.Equal(t,
-		&Msg{
-			Type:   Response,
-			ReqID:  42,
-			Method: "pong",
-			Args:   []interface{}{},
-		}, msg)
+	t.Run("Successful test", func(t *testing.T) {
+		t.Parallel()
 
-	msg, err = ParseRaw([]byte(`[3,"temperature",[28.7]]`))
-	assert.NoError(t, err)
-	assert.Equal(t,
-		&Msg{
-			Type:   EventPublic,
-			ReqID:  0,
-			Method: "temperature",
-			Args:   []interface{}{28.7},
-		}, msg)
-}
+		msg, err := ParseRaw([]byte(`[1,42,"ping",[]]`))
+		assert.NoError(t, err)
+		assert.Equal(t,
+			&Msg{
+				Type:   Request,
+				ReqID:  42,
+				Method: "ping",
+				Args:   []interface{}{},
+			}, msg)
+		msg, err = ParseRaw([]byte(`[2,42,"pong",[]]`))
+		assert.NoError(t, err)
+		assert.Equal(t,
+			&Msg{
+				Type:   Response,
+				ReqID:  42,
+				Method: "pong",
+				Args:   []interface{}{},
+			}, msg)
+		msg, err = ParseRaw([]byte(`[3,"temperature",[28.7]]`))
+		assert.NoError(t, err)
+		assert.Equal(t,
+			&Msg{
+				Type:   EventPublic,
+				ReqID:  0,
+				Method: "temperature",
+				Args:   []interface{}{28.7},
+			}, msg)
+	})
 
-func TestParserErrorsMessageLength(t *testing.T) {
-	msg, err := ParseRaw([]byte(`[1,42,"ping"]`))
-	assert.EqualError(t, err, "message must contain 4 elements")
-	assert.Nil(t, msg)
-}
+	t.Run("Invalid message length", func(t *testing.T) {
+		t.Parallel()
 
-func TestParserErrorsBadJSON(t *testing.T) {
-	msg, err := ParseRaw([]byte(`[1,42,"ping",[]`))
-	assert.EqualError(t, err, "could not parse message: unexpected end of JSON input")
-	assert.Nil(t, msg)
-}
+		msg, err := ParseRaw([]byte(`[1,42,"ping"]`))
+		assert.EqualError(t, err, "message must contain 4 elements")
+		assert.Nil(t, msg)
+	})
 
-func TestParserErrorsType(t *testing.T) {
-	msg, err := ParseRaw([]byte(`[5,42,"ping",[]]`))
-	assert.EqualError(t, err, "message type must be 1, 2, 3 or 4")
-	assert.Nil(t, msg)
+	t.Run("Bad JSON", func(t *testing.T) {
+		t.Parallel()
 
-	msg, err = ParseRaw([]byte(`[5,"ping",[]]`))
-	assert.EqualError(t, err, "message type must be 1, 2, 3 or 4")
-	assert.Nil(t, msg)
+		msg, err := ParseRaw([]byte(`[1,42,"ping",[]`))
+		assert.EqualError(t, err, "could not parse message: unexpected end of JSON input")
+		assert.Nil(t, msg)
+	})
 
-	msg, err = ParseRaw([]byte(`[1.1,42,"pong",[]]`))
-	assert.EqualError(t, err, "failed to parse type: invalid type")
-	assert.Nil(t, msg)
+	t.Run("Invalid types", func(t *testing.T) {
+		t.Parallel()
 
-	msg, err = ParseRaw([]byte(`["1",42,"pong",[]]`))
-	assert.NoError(t, err)
-	assert.NotNil(t, msg)
-}
+		msg, err := ParseRaw([]byte(`[5,42,"ping",[]]`))
+		assert.EqualError(t, err, "message type must be 1, 2, 3 or 4")
+		assert.Nil(t, msg)
 
-func TestParserErrorsRequestID(t *testing.T) {
-	msg, err := ParseRaw([]byte(`[1,"42","ping",[]]`))
-	assert.NoError(t, err)
-	assert.NotNil(t, msg)
+		msg, err = ParseRaw([]byte(`[5,"ping",[]]`))
+		assert.EqualError(t, err, "message type must be 1, 2, 3 or 4")
+		assert.Nil(t, msg)
 
-	msg, err = ParseRaw([]byte(`[1,42.1,"ping",[]]`))
-	assert.EqualError(t, err, "failed to parse request ID: invalid type")
-	assert.Nil(t, msg)
-}
+		msg, err = ParseRaw([]byte(`[1.1,42,"pong",[]]`))
+		assert.EqualError(t, err, "failed to parse type: invalid type")
+		assert.Nil(t, msg)
 
-func TestParserErrorsMethod(t *testing.T) {
-	msg, err := ParseRaw([]byte(`[1,42,true,[]]`))
-	assert.EqualError(t, err, "failed to parse method: invalid type")
-	assert.Nil(t, msg)
-}
+		msg, err = ParseRaw([]byte(`["1",42,"pong",[]]`))
+		assert.NoError(t, err)
+		assert.NotNil(t, msg)
+	})
 
-func TestParserErrorsArgs(t *testing.T) {
-	msg, err := ParseRaw([]byte(`[1,42,"ping",true]`))
-	assert.EqualError(t, err, "failed to parse arguments: invalid type")
-	assert.Nil(t, msg)
+	t.Run("Invalid request ID", func(t *testing.T) {
+		t.Parallel()
 
-	msg, err = ParseRaw([]byte(`[1,42,"ping","hello"]`))
-	assert.EqualError(t, err, "failed to parse arguments: invalid type")
-	assert.Nil(t, msg)
+		msg, err := ParseRaw([]byte(`[1,"42","ping",[]]`))
+		assert.NoError(t, err)
+		assert.NotNil(t, msg)
+
+		msg, err = ParseRaw([]byte(`[1,42.1,"ping",[]]`))
+		assert.EqualError(t, err, "failed to parse request ID: invalid type")
+		assert.Nil(t, msg)
+	})
+
+	t.Run("Invalid method", func(t *testing.T) {
+		t.Parallel()
+
+		msg, err := ParseRaw([]byte(`[1,42,true,[]]`))
+		assert.EqualError(t, err, "failed to parse method: invalid type")
+		assert.Nil(t, msg)
+	})
+
+	t.Run("Invalid arguments", func(t *testing.T) {
+		t.Parallel()
+
+		msg, err := ParseRaw([]byte(`[1,42,"ping",true]`))
+		assert.EqualError(t, err, "failed to parse arguments: invalid type")
+		assert.Nil(t, msg)
+
+		msg, err = ParseRaw([]byte(`[1,42,"ping","hello"]`))
+		assert.EqualError(t, err, "failed to parse arguments: invalid type")
+		assert.Nil(t, msg)
+	})
 }

--- a/pkg/quotes/opendax_test.go
+++ b/pkg/quotes/opendax_test.go
@@ -70,7 +70,11 @@ func (c *ODAPIMock) Close() error {
 }
 
 func TestOpendax_parseOpendaxMsg(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Successful test", func(t *testing.T) {
+		t.Parallel()
+
 		message := protocol.Msg{
 			ReqID:  1,
 			Type:   3,
@@ -97,6 +101,8 @@ func TestOpendax_parseOpendaxMsg(t *testing.T) {
 	})
 
 	t.Run("invalid message", func(t *testing.T) {
+		t.Parallel()
+
 		trade := ""
 		byteMsg, err := json.Marshal(trade)
 		require.NoError(t, err)
@@ -106,6 +112,8 @@ func TestOpendax_parseOpendaxMsg(t *testing.T) {
 	})
 
 	t.Run("invalid message args", func(t *testing.T) {
+		t.Parallel()
+
 		trade := protocol.Msg{
 			ReqID:  1,
 			Type:   3,
@@ -121,7 +129,11 @@ func TestOpendax_parseOpendaxMsg(t *testing.T) {
 }
 
 func TestOpendax_Subscribe(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Successful test", func(t *testing.T) {
+		t.Parallel()
+
 		client := &opendax{
 			conn: &ODAPIMock{
 				messages:    []ODAPIMockMsg{{}},
@@ -134,6 +146,8 @@ func TestOpendax_Subscribe(t *testing.T) {
 	})
 
 	t.Run("Fail test", func(t *testing.T) {
+		t.Parallel()
+
 		client := &opendax{
 			conn: &ODAPIMock{isConnected: false},
 		}
@@ -144,13 +158,19 @@ func TestOpendax_Subscribe(t *testing.T) {
 }
 
 func TestOpendax_Stop(t *testing.T) {
+	t.Parallel()
+
 	client := opendax{conn: &ODAPIMock{}}
 	err := client.Stop()
 	require.NoError(t, err)
 }
 
 func TestOpendax_connect(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Successful case", func(t *testing.T) {
+		t.Parallel()
+
 		connMock := &ODDialerSuccessMock{
 			reconnectAttempted: make(chan bool, 1),
 			messages:           []ODAPIMockMsg{{}},
@@ -170,7 +190,11 @@ func TestOpendax_connect(t *testing.T) {
 }
 
 func TestOpendax_receiveOpendaxMsg(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Error reading from connection", func(t *testing.T) {
+		t.Parallel()
+
 		// Setup an error message
 		outbox := make(chan TradeEvent, 1)
 		client := &opendax{
@@ -198,6 +222,8 @@ func TestOpendax_receiveOpendaxMsg(t *testing.T) {
 	})
 
 	t.Run("Successful test", func(t *testing.T) {
+		t.Parallel()
+
 		update := protocol.Msg{
 			ReqID:  1,
 			Type:   3,

--- a/pkg/quotes/trade_sampler_test.go
+++ b/pkg/quotes/trade_sampler_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestNewTradeSampler(t *testing.T) {
+	t.Parallel()
+
 	defaultPercentage := rand.Int()
 	conf := TradeSamplerConfig{
 		Enabled:           false,
@@ -20,7 +22,11 @@ func TestNewTradeSampler(t *testing.T) {
 }
 
 func TestTradeSampler_Allow(t *testing.T) {
+	t.Parallel()
+
 	t.Run("TradeSampler is not enabled", func(t *testing.T) {
+		t.Parallel()
+
 		conf := TradeSamplerConfig{
 			Enabled:           false,
 			DefaultPercentage: 0,
@@ -31,6 +37,8 @@ func TestTradeSampler_Allow(t *testing.T) {
 	})
 
 	t.Run("DefaultPercentage is in specified range", func(t *testing.T) {
+		t.Parallel()
+
 		conf := TradeSamplerConfig{
 			Enabled:           true,
 			DefaultPercentage: 200, // should be greater than rand.Intn(100)
@@ -41,6 +49,8 @@ func TestTradeSampler_Allow(t *testing.T) {
 	})
 
 	t.Run("Should return false", func(t *testing.T) {
+		t.Parallel()
+
 		conf := TradeSamplerConfig{
 			Enabled:           true,
 			DefaultPercentage: 0,

--- a/pkg/quotes/uniswap.go
+++ b/pkg/quotes/uniswap.go
@@ -59,7 +59,7 @@ func (u *uniswapV3) Subscribe(market Market) error {
 	symbol := market.BaseUnit + market.QuoteUnit
 
 	if _, ok := u.streams.Load(market); ok {
-		return fmt.Errorf("market %s already subscribed", symbol)
+		return fmt.Errorf("%s: %w", market, ErrAlreadySubbed)
 	}
 
 	exists, err := u.isMarketAvailable(market)
@@ -90,7 +90,8 @@ func (u *uniswapV3) Subscribe(market Market) error {
 				to := from.Add(u.windowSize)
 				swaps, err := u.fetchSwaps(market, from, to)
 				if err != nil {
-					logger.Warn("failed to fetch swaps")
+					err = fmt.Errorf("%s: %w", market, err)
+					logger.Warn(err)
 				}
 
 				for _, swap := range swaps {
@@ -121,7 +122,7 @@ func (u *uniswapV3) Subscribe(market Market) error {
 func (u *uniswapV3) Unsubscribe(market Market) error {
 	stream, ok := u.streams.Load(market)
 	if !ok {
-		return fmt.Errorf("market %s not found", market)
+		return fmt.Errorf("%s: %w", market, ErrNotSubbed)
 	}
 
 	stopCh := stream.(chan struct{})

--- a/pkg/quotes/websocket.go
+++ b/pkg/quotes/websocket.go
@@ -2,11 +2,13 @@ package quotes
 
 import (
 	"net/http"
+	"sync"
 
 	"github.com/gorilla/websocket"
 )
 
 type wsTransport interface {
+	IsConnected() bool
 	ReadMessage() (messageType int, p []byte, err error)
 	WriteMessage(messageType int, data []byte) error
 	Close() error
@@ -19,5 +21,39 @@ type wsDialer interface {
 type wsDialWrapper struct{}
 
 func (wsDialWrapper) Dial(url string, header http.Header) (wsTransport, *http.Response, error) {
-	return websocket.DefaultDialer.Dial(url, header)
+	conn, resp, err := websocket.DefaultDialer.Dial(url, header)
+	return &wsConn{conn: conn}, resp, err
+}
+
+type wsConn struct {
+	conn *websocket.Conn
+	mu   *sync.Mutex
+}
+
+func (w *wsConn) IsConnected() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return w.conn != nil
+}
+
+func (w *wsConn) ReadMessage() (messageType int, p []byte, err error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return w.conn.ReadMessage()
+}
+
+func (w *wsConn) WriteMessage(messageType int, data []byte) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return w.conn.WriteMessage(messageType, data)
+}
+
+func (w *wsConn) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return w.conn.Close()
 }


### PR DESCRIPTION
- refactor: use atomic uint64 instead of plain uint64 for request ID in Opendax adapter
- fix: double Subscribe / Unsubscribe
- refactor: simplify Start method of Driver interface
- refactor: unify connection, its mutex and useful helpers in a single type
- test: execute tests in parallel
- feat: avoid double Start / Stop; force execution order Start -> Stop
- refactor: add common errors
