### PR TITLE
refactor: replace interface{} with any for clarity and modernization

### DIFF
--- a/pkg/quotes/interface_test.go
+++ b/pkg/quotes/interface_test.go
@@ -22,7 +22,7 @@ func TestNewDriver(t *testing.T) {
 	testCases := []struct {
 		name       string
 		driverType DriverType
-		expected   interface{}
+		expected   any
 	}{
 		// Centralized exchanges
 		{DriverBinance.String(), DriverBinance, (*binance)(nil)},

--- a/pkg/quotes/kraken.go
+++ b/pkg/quotes/kraken.go
@@ -248,7 +248,7 @@ func (k *kraken) connect() error {
 
 	// Check if Kraken API is online
 
-	var initResp map[string]interface{}
+	var initResp map[string]any
 	if err := json.Unmarshal(msg, &initResp); err != nil {
 		return err
 	}
@@ -315,8 +315,8 @@ func (k *kraken) parseMessage(rawMsg []byte) ([]TradeEvent, error) {
 	// TODO: handle unsubscribe response
 	// TODO: handle error response
 
-	var tradeData []interface{}
-	var eventData map[string]interface{}
+	var tradeData []any
+	var eventData map[string]any
 	eventErr := json.Unmarshal(rawMsg, &eventData)
 	tradeErr := json.Unmarshal(rawMsg, &tradeData)
 
@@ -335,7 +335,7 @@ func (k *kraken) parseMessage(rawMsg []byte) ([]TradeEvent, error) {
 	return k.buildEvents(events)
 }
 
-func (k *kraken) parseEvent(eventData map[string]interface{}) error {
+func (k *kraken) parseEvent(eventData map[string]any) error {
 	if eventData["event"] == "heartbeat" {
 		return nil
 	}
@@ -370,20 +370,20 @@ type krakenTradeDetail struct {
 	Misc      string `json:"misc"`
 }
 
-func (k *kraken) parseTrade(data []interface{}) (trade krakenTrade, err error) {
+func (k *kraken) parseTrade(data []any) (trade krakenTrade, err error) {
 	trade.ChannelID = int(data[0].(float64))
 	trade.ChannelName = data[2].(string)
 	trade.Pair = data[3].(string)
 
 	// Extract trade details
 
-	tradeDetails, ok := data[1].([]interface{})
+	tradeDetails, ok := data[1].([]any)
 	if !ok {
 		return trade, fmt.Errorf("error in type assertion for trade details")
 	}
 
 	for _, item := range tradeDetails {
-		itemDetails, ok := item.([]interface{})
+		itemDetails, ok := item.([]any)
 		if !ok {
 			return trade, fmt.Errorf("error in type assertion for an item in trade details")
 		}

--- a/pkg/quotes/mexc.go
+++ b/pkg/quotes/mexc.go
@@ -224,7 +224,7 @@ func (b *mexc) watchTrades(symbol string, stopCh chan struct{}) {
 	}
 	defer conn.Close()
 
-	subMsg := map[string]interface{}{
+	subMsg := map[string]any{
 		"id":     b.requestID.Load(),
 		"method": "SUBSCRIPTION",
 		"params": []string{"spot@public.deals.v3.api@" + strings.ToUpper(symbol)},
@@ -238,7 +238,7 @@ func (b *mexc) watchTrades(symbol string, stopCh chan struct{}) {
 	for {
 		select {
 		case <-stopCh:
-			unsubMsg := map[string]interface{}{
+			unsubMsg := map[string]any{
 				"id":     b.requestID.Load(),
 				"method": "UNSUBSCRIPTION",
 				"params": []string{"spot@public.deals.v3.api@" + strings.ToUpper(symbol)},
@@ -256,7 +256,7 @@ func (b *mexc) watchTrades(symbol string, stopCh chan struct{}) {
 					loggerMexc.Infow("attempting to reconnect", "attempt", i+1)
 					conn, _, err = websocket.DefaultDialer.Dial("wss://wbs.mexc.com/ws", nil)
 					if err == nil {
-						subMsg := map[string]interface{}{
+						subMsg := map[string]any{
 							"id":     b.requestID.Load(),
 							"method": "SUBSCRIPTION",
 							"params": []string{"spot@public.deals.v3.api@" + strings.ToUpper(symbol)},

--- a/pkg/quotes/opendax_test.go
+++ b/pkg/quotes/opendax_test.go
@@ -80,7 +80,7 @@ func TestOpendax_parse(t *testing.T) {
 			ReqID:  1,
 			Type:   3,
 			Method: "trade",
-			Args:   []interface{}{"btc/usd", 1, 1, 1, 1, 1, "buy", "Opendax"},
+			Args:   []any{"btc/usd", 1, 1, 1, 1, 1, "buy", "Opendax"},
 		}
 		byteMsg, err := message.Encode()
 		require.NoError(t, err)
@@ -121,7 +121,7 @@ func TestOpendax_parse(t *testing.T) {
 			ReqID:  1,
 			Type:   3,
 			Method: "trade",
-			Args:   []interface{}{""},
+			Args:   []any{""},
 		}
 		byteMsg, err := trade.Encode()
 		require.NoError(t, err)
@@ -245,7 +245,7 @@ func TestOpendax_listen(t *testing.T) {
 			ReqID:  1,
 			Type:   3,
 			Method: "trade",
-			Args:   []interface{}{"btc/usd", 1, 1, 1, 1, 1, "buy", "Opendax"},
+			Args:   []any{"btc/usd", 1, 1, 1, 1, 1, "buy", "Opendax"},
 		}
 
 		rawMsg, err := update.Encode()

--- a/pkg/smart_wallet/config.go
+++ b/pkg/smart_wallet/config.go
@@ -42,7 +42,7 @@ func (t Type) String() string {
 }
 
 // UnmarshalYAML unmarshals the YAML representation of a SmartWalletType.
-func (t *Type) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (t *Type) UnmarshalYAML(unmarshal func(any) error) error {
 	var rawValue string
 	err := unmarshal(&rawValue)
 	if err != nil {

--- a/pkg/universal_sigver/client.go
+++ b/pkg/universal_sigver/client.go
@@ -71,7 +71,7 @@ func (b *backend) Verify(ctx context.Context, signer common.Address, messageHash
 	calldata := packIsValidSigCall(signer, messageHash, signature)
 
 	var res string
-	err := b.provider.Client().CallContext(ctx, &res, "eth_call", map[string]interface{}{
+	err := b.provider.Client().CallContext(ctx, &res, "eth_call", map[string]any{
 		"data": hexutil.Encode(calldata),
 	},
 		"latest")

--- a/pkg/userop/blockchain_backend.go
+++ b/pkg/userop/blockchain_backend.go
@@ -14,7 +14,7 @@ import (
 )
 
 type RPCBackend interface {
-	CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error
+	CallContext(ctx context.Context, result any, method string, args ...any) error
 }
 
 func NewRPCBackend(rpcURL url.URL) (RPCBackend, error) {

--- a/pkg/userop/paymaster_type.go
+++ b/pkg/userop/paymaster_type.go
@@ -23,7 +23,7 @@ func (t PaymasterType) String() string {
 }
 
 // UnmarshalYAML unmarshalls the YAML representation of a PaymasterType.
-func (t *PaymasterType) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (t *PaymasterType) UnmarshalYAML(unmarshal func(any) error) error {
 	var rawValue string
 	err := unmarshal(&rawValue)
 	if err != nil {

--- a/pkg/userop/testing/local_blockchain/middleware_test.go
+++ b/pkg/userop/testing/local_blockchain/middleware_test.go
@@ -107,7 +107,7 @@ func TestGasLimitOverrides(t *testing.T) {
 					PreVerificationGas:   responseLimit,
 					PaymasterAndData:     "0xdeadbeef",
 				}
-				jsonResponse := map[string]interface{}{
+				jsonResponse := map[string]any{
 					"jsonrpc": "2.0",
 					"result":  response,
 					"id":      1,

--- a/pkg/userop/testing/public_blockchain/main_test.go
+++ b/pkg/userop/testing/public_blockchain/main_test.go
@@ -139,7 +139,7 @@ func newTransferERC20Call(t *testing.T, token, receiver common.Address, amount d
 }
 
 // Encodes a call to the `contract` with the given `value`, `method` and `args`.
-func newCallFromABI(t *testing.T, contract common.Address, stringABI string, value *big.Int, method string, args ...interface{}) (smart_wallet.Call, error) {
+func newCallFromABI(t *testing.T, contract common.Address, stringABI string, value *big.Int, method string, args ...any) (smart_wallet.Call, error) {
 	ABI, err := abi.JSON(strings.NewReader(stringABI))
 	require.NoError(t, err, "failed to parse ABI")
 


### PR DESCRIPTION
This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.
 
As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.